### PR TITLE
Send message in `html` parse mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Changes
 
+* Send message in `html` parse mode
 * Drop support of ruby 2.4, since it's EOLed
 
 ## 0.1.0 (2020-08-12)

--- a/bot.rb
+++ b/bot.rb
@@ -21,7 +21,7 @@ Telegram::Bot::Client.run(config['telegram_bot_token']) do |bot|
         text = 'There is no changes for specified versions' if text.empty?
         bot.api.send_message(chat_id: message.chat.id,
                              text: text,
-                             parse_mode: 'Markdown')
+                             parse_mode: 'html')
       end
     end
   end

--- a/lib/telegram_github_changes_bot/github_repo_changes.rb
+++ b/lib/telegram_github_changes_bot/github_repo_changes.rb
@@ -53,8 +53,9 @@ class GithubRepoChanges
     return "#{@repo}: #{SAME_MESSAGE}" if @old_ref == @new_ref
     return '' if changes_empty?
 
-    "[#{@repo} changes #{@old_ref}..."\
-    "#{@new_ref}](#{changes_url})\n"
+    changes_text = "#{@repo} changes #{@old_ref}..."\
+                   "#{@new_ref}"
+    "<a href='#{changes_url}'>#{changes_text}</a>\n"
   end
 
   private


### PR DESCRIPTION
Old variant cause some exceptions with newlines and
`_` symbols in random.
Seems then Telegram Backend changed something on their side
Sometimes they start to appear, sometimes they dissapear
Errors like this:
```
/usr/local/bundle/gems/telegram-bot-ruby-0.12.0/lib/telegram/bot/api.rb:79:in `call': Telegram API has returned the error. (ok: "false", error_code: "400", description: "Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 41") (Telegram::Bot::Exceptions::ResponseError)
```