### PR TITLE
Allow failures on `ruby-head` in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,13 +3,14 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.allow-failures }}
     strategy:
       matrix:
         ruby: [2.5, 2.6, 2.7]
-      allow-failures: [ false ]
-      include:
-        - ruby: head
-          allow-failures: true
+        allow-failures: [false]
+        include:
+          - ruby: head
+            allow-failures: true
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -5,7 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, head]
+        ruby: [2.5, 2.6, 2.7]
+      allow-failures: [ false ]
+      include:
+        - ruby: head
+          allow-failures: true
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased (master)
 
+### Changes
+
+* Allow failures on `ruby-head` in CI
+
 ## 0.2.0 (2020-08-31)
 
 ### Changes


### PR DESCRIPTION
From [yesterday](https://github.com/ruby/ruby/commit/21c62fb670b1646c5051a46d29081523cd782f11) ruby 2.8 is ruby 3.0 and some gems just
can't install it

Until at least https://github.com/simplecov-ruby/simplecov-html/commit/6567856c6940e285bbb70cce98edca60c7dfefdd2 is released