### PR TITLE
CI only on current stable ruby and ruby-head

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,7 +6,7 @@ jobs:
     continue-on-error: ${{ matrix.allow-failures }}
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7]
+        ruby: [2.7]
         allow-failures: [false]
         include:
           - ruby: head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Allow failures on `ruby-head` in CI
 * Fix new warnings from `rubocop` v0.93.0 update
+* CI only on current stable ruby and ruby-head
 
 ## 0.2.0 (2020-08-31)
 


### PR DESCRIPTION
A lot of tests result github temporaly banning API keys
Those extra tests mostly useless, since product run only in docker
and only on current stable ruby (2.7)
And tests on ruby-head just in case