### PR TITLE
Bump Node.js from 16 to 20 in markdownlint CI job

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '20'
       - name: Check markdown files using `markdownlint`
         run: |
           npm install -g markdownlint-cli


### PR DESCRIPTION
Node 16 is EOL and doesn't support the `v` regex flag required by newer markdownlint-cli.