### PR TITLE
Fix fetch_refs assigning same tag to both old_ref and new_ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,34 @@ By file `config.json` with data
 which is compatible with Gitea and GitHub classic personal access tokens.
 GitHub fine-grained personal access tokens are not supported.
 
+## Usage
+
+### Compare two versions
+
+```text
+/get_changes v6.5.0.46...v6.5.0.57
+```
+
+Returns a link to the diff between two specified refs (tags or branches)
+for each repo listed in `config.json`.
+
+### Compare a version with the latest tag
+
+```text
+/get_changes v6.5.0.46
+```
+
+Returns a link to the diff between the specified ref and the latest tag
+in the repository. Useful to see what changed since your current version.
+
+### Help
+
+```text
+/help
+```
+
+Shows usage instructions.
+
 ## Docker compose
 
 ```bash

--- a/lib/telegram_github_changes_bot/github_repo_changes.rb
+++ b/lib/telegram_github_changes_bot/github_repo_changes.rb
@@ -34,9 +34,10 @@ class GithubRepoChanges
 
   # @return [String] link to changes to send in message
   def link_to_changes
-    @logger.info("Fetching changes for `#{@repo}` " \
-                 "between `#{@old_ref}` and `#{@new_ref}`")
+    @logger.info("Fetching changes for `#{@repo}` between `#{@old_ref}` and `#{@new_ref}`")
     fetch_refs
+    return "Please specify versions: /get_changes version1...version2\n" unless refs_present?
+
     check_ref_existence
 
     return '' if non_existing_refs_allowed?

--- a/lib/telegram_github_changes_bot/github_repo_changes/ref_helper.rb
+++ b/lib/telegram_github_changes_bot/github_repo_changes/ref_helper.rb
@@ -9,15 +9,18 @@ module RefHelper
     @client.ref_exist?(@repo, ref_name)
   end
 
-  # Fetch refs values (fill @new_ref and @old_ref)
+  # Fetch refs values (fill @new_ref from latest tag when only @old_ref is provided)
   # @return [nil]
   def fetch_refs
     return if @new_ref && @old_ref
 
-    latest = @client.latest_tag(@repo)
-    @new_ref ||= latest&.dig(:name)
-    @old_ref ||= latest&.dig(:name)
+    @new_ref ||= @client.latest_tag(@repo)&.dig(:name)
     nil
+  end
+
+  # @return [Boolean] true if both refs are present
+  def refs_present?
+    @old_ref && @new_ref
   end
 
   private

--- a/spec/github_repo_changes_fetch_refs_spec.rb
+++ b/spec/github_repo_changes_fetch_refs_spec.rb
@@ -10,10 +10,25 @@ describe GithubRepoChanges do
     expect(repo.new_ref).to be_nil
   end
 
-  it 'fetch_refs sets old_ref to nil when repo has no tags' do
-    client = instance_double(GitApiClient, latest_tag: nil)
-    repo = described_class.new(repo: 'test/empty', client: client)
+  it 'fetch_refs does not set old_ref' do
+    client = instance_double(GitApiClient, latest_tag: { name: 'v1.0' })
+    repo = described_class.new(repo: 'test/repo', client: client)
     repo.fetch_refs
     expect(repo.old_ref).to be_nil
+  end
+
+  it 'fetch_refs sets new_ref from latest tag' do
+    client = instance_double(GitApiClient, latest_tag: { name: 'v1.0' })
+    repo = described_class.new(repo: 'test/repo', client: client)
+    repo.fetch_refs
+    expect(repo.new_ref).to eq('v1.0')
+  end
+
+  it 'fetch_refs skips when both refs already set' do
+    repo = described_class.new(repo: 'test/repo', client: instance_double(GitApiClient))
+    repo.old_ref = 'v1.0'
+    repo.new_ref = 'v2.0'
+    repo.fetch_refs
+    expect(repo.new_ref).to eq('v2.0')
   end
 end

--- a/spec/github_repo_changes_single_ref_spec.rb
+++ b/spec/github_repo_changes_single_ref_spec.rb
@@ -11,9 +11,7 @@ describe GithubRepoChanges, :vcr do
   end
 
   it 'Check correct message if single ref - is the latest ref' do
-    github_changes.fetch_refs
-    newest_ref = github_changes.new_ref
-    github_changes.refs_from_message("/get_changes #{newest_ref}")
+    github_changes.refs_from_message('/get_changes win-v4.3.0.110')
     expect(github_changes.link_to_changes)
       .to match(/Your specified version is the latest version/)
   end

--- a/spec/github_repo_changes_without_ref_spec.rb
+++ b/spec/github_repo_changes_without_ref_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe GithubRepoChanges, :vcr do
+describe GithubRepoChanges do
   let(:github_changes) { changes_bot.repo(name: 'ONLYOFFICE/sdkjs') }
 
   describe 'Check changes without refs' do
@@ -14,6 +14,13 @@ describe GithubRepoChanges, :vcr do
 
     it 'expect new_ref is nil' do
       expect(github_changes.new_ref).to be_nil
+    end
+
+    it 'link_to_changes asks to specify versions' do
+      client = instance_double(GitApiClient, latest_tag: nil)
+      repo = described_class.new(repo: 'test/repo', client: client)
+      repo.refs_from_message('/get_changes')
+      expect(repo.link_to_changes).to include('Please specify versions')
     end
   end
 end


### PR DESCRIPTION
fetch_refs used latest_tag (per_page: 1) for both refs, so old_ref == new_ref always, producing no diff output.

Now fetch_refs only fills new_ref from latest tag (for single-ref usage like `/get_changes v1.0`). When no refs are provided, bot returns a message asking user to specify versions.

Also add usage examples to README.